### PR TITLE
fix(release): use whitespace-insensitive version extraction in verify-version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,14 +65,26 @@ jobs:
           tag="${GITHUB_REF#refs/tags/v}"
           echo "Tag version: $tag"
           echo "version=$tag" >> "$GITHUB_OUTPUT"
-      - name: Cross-check against Cargo.toml
+      - name: Cross-check tag against every workspace Cargo.toml
+        # The grep+sed version assumed `version = "X"` with single
+        # whitespace; the workspace files actually use aligned columns
+        # (`version     = "X"`), making the regex miss and the
+        # extracted version blank. awk -F'"' is whitespace-insensitive
+        # and pulls the quoted value directly.
         run: |
-          cargo_ver="$(grep -E '^version =' crates/hsh/Cargo.toml | head -1 | sed -E 's/version = "([^"]+)"/\1/')"
-          if [ "$cargo_ver" != "${{ steps.extract.outputs.version }}" ]; then
-            echo "::error::tag ${{ steps.extract.outputs.version }} != crates/hsh Cargo.toml $cargo_ver"
-            exit 1
-          fi
-          echo "OK: tag and Cargo.toml agree on $cargo_ver"
+          tag_ver="${{ steps.extract.outputs.version }}"
+          fail=0
+          for manifest in crates/hsh/Cargo.toml crates/hsh-cli/Cargo.toml \
+                          crates/hsh-kms/Cargo.toml crates/hsh-digest/Cargo.toml; do
+            cargo_ver="$(awk -F'"' '/^[[:space:]]*version[[:space:]]*=/ {print $2; exit}' "$manifest")"
+            if [ "$cargo_ver" != "$tag_ver" ]; then
+              echo "::error::tag $tag_ver != $manifest $cargo_ver"
+              fail=1
+            else
+              echo "OK: $manifest = $cargo_ver"
+            fi
+          done
+          exit "$fail"
 
   # ---------------------------------------------------------------------
   # SBOM generation via cargo-about.


### PR DESCRIPTION
## Summary

The v0.0.9 tag push triggered the Release workflow (run [26335000900](https://github.com/sebastienrousseau/hsh/actions/runs/26335000900)) which failed at `verify-version` before reaching `sbom` / `attest` / `publish` / `github-release`. Root cause:

The `Cross-check against Cargo.toml` step used `grep -E '^version =' …` which assumed single-whitespace between key and `=`. The workspace Cargo.toml files actually use aligned columns:

```toml
version     = "0.0.9"
```

so the regex missed, sed got empty input, and the comparison reported `tag 0.0.9 != crates/hsh Cargo.toml ` (empty rhs).

## Fix

Switched to `awk -F'"' '/^[[:space:]]*version[[:space:]]*=/ {print $2; exit}'` which is column-alignment-agnostic and pulls the quoted value directly. Also expanded the check to cover all four workspace manifests (was only crates/hsh).

Verified locally — extraction now returns `0.0.9` for hsh, hsh-cli, hsh-kms, hsh-digest.

## Test plan

- [x] `python3 yaml.safe_load` parses release.yml cleanly
- [x] Local awk extraction returns the right version for every workspace Cargo.toml
- [ ] After merge: delete + recreate `v0.0.9` tag so the Release workflow re-runs with the fixed step