### PR TITLE
ci(release): publish to crates.io via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,8 @@ jobs:
     environment: crates-io
     permissions:
       contents: read
+      # OIDC token for crates.io trusted publishing.
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -212,6 +214,14 @@ jobs:
           go version
           cmake --version | head -1
           clang --version | head -1
+      # Trusted publishing: swaps this job's OIDC identity for a temporary
+      # crates.io token, revoked when the job ends. Each of the five
+      # crates published below needs its own trusted publisher on
+      # crates.io (repo + release.yml + environment crates-io).
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
       - name: "Cargo publish (dep order: kms → digest → backend-awslc → hsh → cli)"
         # `cargo publish` for hsh / hsh-cli fails-fast if the transitive
         # crates haven't appeared on crates.io yet. The `sleep` between
@@ -220,7 +230,7 @@ jobs:
         # non-workspace member, so it's published via --manifest-path
         # rather than -p.
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_API_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           cargo publish -p hsh-kms     --token "$CARGO_REGISTRY_TOKEN"
           sleep 30


### PR DESCRIPTION
Replaces the stored crates.io token with an OIDC exchange. crates.io
issues a short-lived token and the auth action's post step revokes it
when the job ends. Nothing is stored, so there is nothing to rotate and
nothing to leak.

The publish job gains `id-token: write`, and the registry token now
comes from the auth action's output rather than repository secrets.

Trusted publishing is configured **per crate**, and this workflow
publishes 4 published + hsh-backend-awslc. Every one needs its own trusted publisher on
crates.io: repository owner sebastienrousseau, workflow release.yml,
environment crates-io. Releases here are tag-triggered, so merging ahead of that
configuration changes nothing until the next tag is pushed.

actionlint reports no new findings.


Assisted-by: Claude:claude-opus-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)